### PR TITLE
feat: extract envName for deploy/ prefix branch [DPT-1539]

### DIFF
--- a/src/pipeline-template-cdk/bin/code-pipeline-app.ts
+++ b/src/pipeline-template-cdk/bin/code-pipeline-app.ts
@@ -4,9 +4,18 @@ import * as cdk from "aws-cdk-lib";
 import { Utility } from "./utility";
 import { CodePipelineStack } from "../lib/code-pipeline-stack";
 
+const githubRepositoryName = ensureEnvironmentVariable(`GITHUB_REPOSITORY_NAME`);
+const githubRepositoryOwner = ensureEnvironmentVariable("GITHUB_REPOSITORY_OWNER");
+const githubRepositoryBranch = ensureEnvironmentVariable("GITHUB_REPOSITORY_BRANCH");
+
+// extract env name for branches prefixed with deploy/
+const envName = githubRepositoryBranch.toLowerCase().startsWith("deploy/")
+    ? githubRepositoryBranch.substring("deploy/".length)
+    : githubRepositoryBranch;
+
 const app = new cdk.App();
 const projectName = Utility.sanitizeStackName(
-  `${process.env.GITHUB_REPOSITORY_NAME}-${process.env.GITHUB_REPOSITORY_BRANCH}`
+  `${githubRepositoryName}-${envName}`
 ).toLowerCase();
 
 function ensureEnvironmentVariable(variableName: string): string {
@@ -17,9 +26,10 @@ function ensureEnvironmentVariable(variableName: string): string {
 }
 
 new CodePipelineStack(app, `PLF-${projectName}`, {
-  githubRepositoryName: ensureEnvironmentVariable(`GITHUB_REPOSITORY_NAME`),
-  githubRepositoryOwner: ensureEnvironmentVariable("GITHUB_REPOSITORY_OWNER"),
-  githubRepositoryBranch: ensureEnvironmentVariable("GITHUB_REPOSITORY_BRANCH"),
+  githubRepositoryName: githubRepositoryName,
+  githubRepositoryOwner: githubRepositoryOwner,
+  githubRepositoryBranch: githubRepositoryBranch,
+  envName: envName,
   buildAsRoleArn: process.env.BUILD_AS_ROLE_ARN,
   buildSpecFileRelativeLocation: process.env.BUILD_SPEC_RELATIVE_LOCATION,
   gitHubTokenSecretArn: process.env.GITHUB_TOKEN_SECRET_ARN,

--- a/src/pipeline-template-cdk/lib/code-build-project.ts
+++ b/src/pipeline-template-cdk/lib/code-build-project.ts
@@ -15,6 +15,7 @@ export interface CodeBuildProjectProps {
   githubRepositoryName: string;
   githubRepositoryOwner: string;
   githubRepositoryBranch: string;
+  envName: string,
   projectName: string;
   artifactsBucketName: string;
   deployViaGitHubActions: boolean;
@@ -53,7 +54,7 @@ export class CodeBuildProject extends Construct {
       webhook: false,
       cloneDepth: 1,
       fetchSubmodules: false,
-      ...(props.deployViaGitHubActions ? { branchOrRef: `refs/heads/${props.githubRepositoryBranch.toLowerCase()}` } : {}),
+      ...(props.deployViaGitHubActions ? { branchOrRef: `refs/heads/${props.githubRepositoryBranch}` } : {}),
     });
 
     const buildAsRole = iam.Role.fromRoleArn(
@@ -75,11 +76,11 @@ export class CodeBuildProject extends Construct {
       projectName: `PLF-${props.projectName}`,
       environmentVariables: {
         ENV_NAME: {
-          value: props.githubRepositoryBranch.toLowerCase(),
+          value: props.envName.toLowerCase(),
           type: codebuild.BuildEnvironmentVariableType.PLAINTEXT,
         },
         STAGE_ENV_NAME: {
-          value: props.githubRepositoryBranch.toLowerCase(),
+          value: props.envName.toLowerCase(),
           type: codebuild.BuildEnvironmentVariableType.PLAINTEXT,
         },
         STAGE_PACKAGE_BUCKET_NAME: {

--- a/src/pipeline-template-cdk/lib/code-pipeline-stack.ts
+++ b/src/pipeline-template-cdk/lib/code-pipeline-stack.ts
@@ -10,6 +10,7 @@ export class CodePipelineStackProps implements cdk.StackProps {
   readonly githubRepositoryName: string;
   readonly githubRepositoryOwner: string;
   readonly githubRepositoryBranch: string;
+  readonly envName: string;
   readonly projectName: string;
   readonly buildSpecFileRelativeLocation?: string;
   artifactsBucket?: string;
@@ -67,6 +68,7 @@ export class CodePipelineStack extends cdk.Stack {
       githubRepositoryBranch: props.githubRepositoryBranch,
       githubRepositoryName: props.githubRepositoryName,
       githubRepositoryOwner: props.githubRepositoryOwner,
+      envName: props.envName,
       projectName: props.projectName,
       buildSpecLocationOverride: props.buildSpecFileRelativeLocation,
       buildAsRoleArn: props.buildAsRoleArn,
@@ -80,6 +82,7 @@ export class CodePipelineStack extends cdk.Stack {
         githubRepositoryBranch: props.githubRepositoryBranch,
         githubRepositoryName: props.githubRepositoryName,
         githubRepositoryOwner: props.githubRepositoryOwner,
+        envName: props.envName,
         projectName: props.projectName,
         buildAsRoleArn: props.buildAsRoleArn,
         buildProject: builder.buildProject,

--- a/src/pipeline-template-cdk/lib/code-pipeline.ts
+++ b/src/pipeline-template-cdk/lib/code-pipeline.ts
@@ -14,6 +14,7 @@ export interface CodePipelineProps {
   githubRepositoryOwner: string;
   githubRepositoryName: string;
   gitHubTokenSecretArn: string;
+  envName: string,
   buildAsRoleArn: string;
   projectName: string;
   buildProject: IProject;
@@ -98,7 +99,7 @@ export class CodePipeline extends Construct {
       props.artifactsBucketName
     );
 
-    let objectPrefix = `${props.githubRepositoryName}/${props.githubRepositoryBranch}`;
+    let objectPrefix = `${props.githubRepositoryName}/${props.envName}`;
 
     const publishAction = new codePipelineActions.S3DeployAction({
       actionName: "S3Deploy",


### PR DESCRIPTION
- If the branch has `deploy/` prefix, extract the suffix as an environment name - then use that name where appropriate instead of branch name