### PR TITLE
feat: update CodeBuild image to Ubuntu standard:6.0 [DPT-1619]

### DIFF
--- a/src/pipeline-template-cdk/lib/code-build-project.ts
+++ b/src/pipeline-template-cdk/lib/code-build-project.ts
@@ -68,7 +68,7 @@ export class CodeBuildProject extends Construct {
       role: buildAsRole,
       source: gitHubSource,
       environment: {
-        buildImage: codebuild.LinuxBuildImage.STANDARD_5_0,
+        buildImage: codebuild.LinuxBuildImage.STANDARD_6_0,
         privileged: true,
       },
       timeout: cdk.Duration.hours(2),


### PR DESCRIPTION
Update the CodeBuild image for PLF CodeBuild projects to newest `Ubuntu standard:6.0`. It is needed to use Node 16 in CodeBuild.