### PR TITLE
feat: option to allow all refs/branches for OIDC role [SPX-7560]

### DIFF
--- a/packages/cdk/bin/code-pipeline-app.ts
+++ b/packages/cdk/bin/code-pipeline-app.ts
@@ -35,6 +35,7 @@ new CodePipelineStack(app, `PLF-${projectName}`, {
   gitHubTokenSecretArn: process.env.GITHUB_TOKEN_SECRET_ARN,
   artifactsBucket: process.env.ARTIFACTS_BUCKET,
   deployViaGitHubActions: process.env.DEPLOY_VIA_GITHUB_ACTIONS == 'true',
+  githubOidcAllowAllRefs: process.env.GITHUB_OIDC_ALLOW_ALL_REFS == 'true',
   projectName: projectName,
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,

--- a/packages/cdk/src/code-build-project.ts
+++ b/packages/cdk/src/code-build-project.ts
@@ -16,6 +16,7 @@ export interface CodeBuildProjectProps {
   projectName: string;
   artifactsBucketName: string;
   deployViaGitHubActions: boolean;
+  githubOidcAllowAllRefs: boolean;
   buildSpecLocationOverride?: string;
 }
 export class CodeBuildProject extends Construct {
@@ -111,7 +112,7 @@ export class CodeBuildProject extends Construct {
       provider,
       owner: props.githubRepositoryOwner,
       repo: props.githubRepositoryName,
-      filter: `ref:refs/heads/${props.githubRepositoryBranch}`,
+      filter: props.githubOidcAllowAllRefs ? '*' : `ref:refs/heads/${props.githubRepositoryBranch}`,
       maxSessionDuration: cdk.Duration.hours(3),
     });
     executionRole.addToPolicy(

--- a/packages/cdk/src/code-pipeline-stack.ts
+++ b/packages/cdk/src/code-pipeline-stack.ts
@@ -18,6 +18,7 @@ export class CodePipelineStackProps implements cdk.StackProps {
   buildAsRoleArn?: string;
   gitHubTokenSecretArn?: string;
   deployViaGitHubActions?: boolean;
+  githubOidcAllowAllRefs?: boolean;
 }
 
 export class CodePipelineStack extends cdk.Stack {
@@ -71,6 +72,7 @@ export class CodePipelineStack extends cdk.Stack {
       buildSpecLocationOverride: props.buildSpecFileRelativeLocation,
       buildAsRoleArn: props.buildAsRoleArn,
       deployViaGitHubActions: props.deployViaGitHubActions || false,
+      githubOidcAllowAllRefs: props.githubOidcAllowAllRefs || false,
     });
 
     if (!props.deployViaGitHubActions) {


### PR DESCRIPTION
- New env var `GITHUB_OIDC_ALLOW_ALL_REFS` to allow all refs (i.e. use `filter = *`) for OIDC role
- Allows invoking a CodeBuild from a non-defined branch (e.g. to reuse a CodeBuild project for dev branch tests/builds)